### PR TITLE
Remove trading dashboard link from home screen

### DIFF
--- a/index.html
+++ b/index.html
@@ -63,11 +63,6 @@
       Media Requests
     </a>
     
-    <a href="https://trading.elikloft.com" target="_blank" class="service-link" style="text-decoration: none; color: #555; padding: 0.5rem 1rem; border: 1px solid #ddd; border-radius: 4px; transition: all 0.3s; background: #f8f9fa;">
-      <i class="fas fa-chart-line" style="margin-right: 0.5rem;"></i>
-      Trading Dashboard
-    </a>
-    
     <a href="/timing" class="service-link" style="text-decoration: none; color: #555; padding: 0.5rem 1rem; border: 1px solid #ddd; border-radius: 4px; transition: all 0.3s; background: #f8f9fa;">
       <i class="fas fa-stopwatch" style="margin-right: 0.5rem;"></i>
       LoRa Timing System


### PR DESCRIPTION
Removes the Trading Dashboard link from the Services & Projects section on the home screen. The page itself is preserved for future use.

Closes #5

Generated with [Claude Code](https://claude.ai/code)